### PR TITLE
Add posts component

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "codegen": "graphql-codegen --config .graphqlrc.ts"
   },
   "dependencies": {
+    "@graphql-typed-document-node/core": "^3.2.0",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-navigation-menu": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
     "codegen": "graphql-codegen --config .graphqlrc.ts"
   },
   "dependencies": {
+    "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-navigation-menu": "^1.1.4",
+    "@radix-ui/react-progress": "^1.0.3",
     "@radix-ui/react-slot": "^1.0.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
@@ -20,6 +22,7 @@
     "next-themes": "^0.2.1",
     "react": "^18",
     "react-dom": "^18",
+    "react-resizable-panels": "^2.0.12",
     "styled-components": "^6.1.8",
     "tailwind-merge": "^2.2.1",
     "tailwindcss-animate": "^1.0.7"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,12 +5,18 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@radix-ui/react-dialog':
+    specifier: ^1.0.5
+    version: 1.0.5(@types/react-dom@18.2.18)(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0)
   '@radix-ui/react-dropdown-menu':
     specifier: ^2.0.6
     version: 2.0.6(@types/react-dom@18.2.18)(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0)
   '@radix-ui/react-navigation-menu':
     specifier: ^1.1.4
     version: 1.1.4(@types/react-dom@18.2.18)(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0)
+  '@radix-ui/react-progress':
+    specifier: ^1.0.3
+    version: 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0)
   '@radix-ui/react-slot':
     specifier: ^1.0.2
     version: 1.0.2(@types/react@18.2.55)(react@18.2.0)
@@ -35,6 +41,9 @@ dependencies:
   react-dom:
     specifier: ^18
     version: 18.2.0(react@18.2.0)
+  react-resizable-panels:
+    specifier: ^2.0.12
+    version: 2.0.12(react-dom@18.2.0)(react@18.2.0)
   styled-components:
     specifier: ^6.1.8
     version: 6.1.8(react-dom@18.2.0)(react@18.2.0)
@@ -1683,6 +1692,40 @@ packages:
       react: 18.2.0
     dev: false
 
+  /@radix-ui/react-dialog@1.0.5(@types/react-dom@18.2.18)(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-GjWJX/AUpB703eEBanuBnIWdIXg6NvJFCXcNlSZk4xdszCdhrJgBoUd1cGk67vFO+WdA2pfI/plOpqz/5GUP6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.9
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.55)(react@18.2.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.55)(react@18.2.0)
+      '@radix-ui/react-dismissable-layer': 1.0.5(@types/react-dom@18.2.18)(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-focus-guards': 1.0.1(@types/react@18.2.55)(react@18.2.0)
+      '@radix-ui/react-focus-scope': 1.0.4(@types/react-dom@18.2.18)(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.2.55)(react@18.2.0)
+      '@radix-ui/react-portal': 1.0.4(@types/react-dom@18.2.18)(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-presence': 1.0.1(@types/react-dom@18.2.18)(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.2.55)(react@18.2.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.2.55)(react@18.2.0)
+      '@types/react': 18.2.55
+      '@types/react-dom': 18.2.18
+      aria-hidden: 1.2.3
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-remove-scroll: 2.5.5(@types/react@18.2.55)(react@18.2.0)
+    dev: false
+
   /@radix-ui/react-direction@1.0.1(@types/react@18.2.55)(react@18.2.0):
     resolution: {integrity: sha512-RXcvnXgyvYvBEOhCBuddKecVkoMiI10Jcm5cTI7abJRAHYfFxeu+FBQs/DvdxSYucxR5mna0dNsL6QFlds5TMA==}
     peerDependencies:
@@ -1961,6 +2004,28 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.9
       '@radix-ui/react-slot': 1.0.2(@types/react@18.2.55)(react@18.2.0)
+      '@types/react': 18.2.55
+      '@types/react-dom': 18.2.18
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /@radix-ui/react-progress@1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-5G6Om/tYSxjSeEdrb1VfKkfZfn/1IlPWd731h2RfPuSbIfNUgfqAwbKfJCg/PP6nuUCTrYzalwHSpSinoWoCag==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.9
+      '@radix-ui/react-context': 1.0.1(@types/react@18.2.55)(react@18.2.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.2.18)(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0)
       '@types/react': 18.2.55
       '@types/react-dom': 18.2.18
       react: 18.2.0
@@ -5611,6 +5676,16 @@ packages:
       tslib: 2.6.2
       use-callback-ref: 1.3.1(@types/react@18.2.55)(react@18.2.0)
       use-sidecar: 1.1.2(@types/react@18.2.55)(react@18.2.0)
+    dev: false
+
+  /react-resizable-panels@2.0.12(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-m0cfwlVQ+460iQbOSVfs3MljVniHI/LGpHGQBa7aNCYUYwaERHcf5W/lCTsoRhbGQfMW9An0M8gxUHILA53Jeg==}
+    peerDependencies:
+      react: ^16.14.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /react-style-singleton@2.2.1(@types/react@18.2.55)(react@18.2.0):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@graphql-typed-document-node/core':
+    specifier: ^3.2.0
+    version: 3.2.0(graphql@16.8.1)
   '@radix-ui/react-dialog':
     specifier: ^1.0.5
     version: 1.0.5(@types/react-dom@18.2.18)(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0)
@@ -1384,7 +1387,6 @@ packages:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 16.8.1
-    dev: true
 
   /@humanwhocodes/config-array@0.11.14:
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
@@ -4315,7 +4317,6 @@ packages:
   /graphql@16.8.1:
     resolution: {integrity: sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
-    dev: true
 
   /has-bigints@1.0.2:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -1,3 +1,7 @@
 export default async function Page() {
-  return <div>Account</div>;
+  return (
+    <div className="flex min-h-[calc(100vh-8rem)] flex-wrap items-center justify-center gap-5 p-5">
+      Account
+    </div>
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,3 @@
 export default function Home() {
-  return <div>Home</div>;
+  return <main className="flex min-h-screen flex-col items-center justify-between p-24">Home</main>;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,7 @@
 export default function Home() {
-  return <main className="flex min-h-screen flex-col items-center justify-between p-24">Home</main>;
+  return (
+    <div className="flex min-h-[calc(100vh-8rem)] flex-wrap items-center justify-center gap-5 p-5">
+      Home
+    </div>
+  );
 }

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -1,0 +1,75 @@
+/* eslint-disable @next/next/no-img-element */
+import React from "react";
+
+import { notFound } from "next/navigation";
+import { PostBySlugDocument } from "@/gql/graphql";
+import { executeGraphql } from "@/lib/graphql";
+import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
+
+function processTextToElements(text: string): JSX.Element[] {
+  const sentences = text.split(". ");
+  const elements: JSX.Element[] = [];
+  let addIndentationNext = false;
+
+  sentences.forEach((sentence, index) => {
+    if (sentence.trim()) {
+      const className = addIndentationNext ? "indent-10 inline-block" : "";
+      if (addIndentationNext) addIndentationNext = false;
+
+      elements.push(
+        <span key={`sentence-${index}`} className={className}>
+          {sentence.trim() +
+            (index < sentences.length - 1 && sentence.endsWith("." || ". ") ? "" : ".")}
+        </span>,
+      );
+
+      if ((index + 1) % 5 === 0 && index !== sentences.length - 1) {
+        elements.push(<br key={`break-${index}`} />, <br key={`break-additional-${index}`} />);
+        addIndentationNext = true;
+      }
+    }
+  });
+  return elements;
+}
+
+export default async function Post({ params: { slug } }: { params: { slug: string } }) {
+  const post = await executeGraphql(PostBySlugDocument, {
+    slug: slug,
+  });
+
+  if (!post) {
+    return notFound();
+  }
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-between gap-10 px-24 py-5">
+      <h1 className="flex text-center text-4xl font-extrabold italic">{post.post?.title}</h1>
+      <div className="flex flex-row  gap-10">
+        <Dialog>
+          <DialogTrigger>
+            {" "}
+            <img
+              className="max-w-xl rounded-lg hover:opacity-90"
+              src={post.post?.coverImage?.url}
+              alt="Image"
+            />
+          </DialogTrigger>
+          <DialogContent className="h-[600px] w-[2300px]">
+            <img className="rounded-lg" src={post.post?.coverImage?.url} alt="Image" />
+          </DialogContent>
+        </Dialog>
+        <div className="flex w-full flex-col justify-center gap-5 pt-3">
+          <p className="flex w-full  items-center text-3xl">{post.post?.excerpt}</p>
+          <p className="flex justify-end">
+            {post.post?.author?.name ? `~${post.post?.author.name}` : ""}
+          </p>
+        </div>
+      </div>
+      <div className="w-full">
+        <p className="w-full text-justify indent-10">
+          {processTextToElements(post.post?.content.text || "")}
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -4,7 +4,6 @@ import React from "react";
 import { notFound } from "next/navigation";
 import { PostBySlugDocument } from "@/gql/graphql";
 import { executeGraphql } from "@/lib/graphql";
-import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
 
 function processTextToElements(text: string): JSX.Element[] {
   const sentences = text.split(". ");
@@ -42,24 +41,12 @@ export default async function Post({ params: { slug } }: { params: { slug: strin
   }
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-between gap-10 px-24 py-5">
-      <h1 className="flex text-center text-4xl font-extrabold italic">{post.post?.title}</h1>
+    <main className="flex min-h-[calc(100vh-132px)] flex-col items-center justify-between gap-10 px-24 py-5">
+      <h1 className="flex text-center text-3xl font-extrabold italic">{post.post?.title}</h1>
       <div className="flex flex-row  gap-10">
-        <Dialog>
-          <DialogTrigger>
-            {" "}
-            <img
-              className="max-w-xl rounded-lg hover:opacity-90"
-              src={post.post?.coverImage?.url}
-              alt="Image"
-            />
-          </DialogTrigger>
-          <DialogContent className="h-[600px] w-[2300px]">
-            <img className="rounded-lg" src={post.post?.coverImage?.url} alt="Image" />
-          </DialogContent>
-        </Dialog>
+        <img className="max-w-xl rounded-lg" src={post.post?.coverImage?.url} alt="Image" />
         <div className="flex w-full flex-col justify-center gap-5 pt-3">
-          <p className="flex w-full  items-center text-3xl">{post.post?.excerpt}</p>
+          <p className="flex w-full  items-center text-2xl">{post.post?.excerpt}</p>
           <p className="flex justify-end">
             {post.post?.author?.name ? `~${post.post?.author.name}` : ""}
           </p>

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -1,10 +1,20 @@
+import Link from "next/link";
+import { PostCard } from "@/components/PostCard";
 import { PostsGetListDocument } from "@/gql/graphql";
 import { executeGraphql } from "@/lib/graphql";
 
 export default async function Page() {
   const posts = await executeGraphql(PostsGetListDocument);
 
-  console.log("posts", posts);
-
-  return <div>{JSON.stringify(posts)}</div>;
+  return (
+    <main className="flex min-h-96 flex-col items-center justify-between p-24">
+      <ul className="flex flex-wrap items-center justify-center gap-10">
+        {posts.posts.map((post) => (
+          <Link href={`/posts/${post.slug}`} key={post.id}>
+            <PostCard post={post} key={post.id} />
+          </Link>
+        ))}
+      </ul>
+    </main>
+  );
 }

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -8,7 +8,7 @@ export default async function Page() {
 
   return (
     <main className="flex min-h-96 flex-col items-center justify-between p-24">
-      <ul className="flex flex-wrap items-center justify-center gap-10">
+      <ul className="flex flex-wrap items-center justify-center gap-5">
         {posts.posts.map((post) => (
           <Link href={`/posts/${post.slug}`} key={post.id}>
             <PostCard post={post} key={post.id} />

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -7,9 +7,9 @@ export const Posts = async () => {
   const posts = await executeGraphql(PostsGetListDocument);
 
   return (
-    <ul className="p-5flex-wrap flex min-h-screen items-center justify-center gap-5">
+    <ul className="flex min-h-[calc(100vh-8rem)] flex-wrap items-center justify-center gap-5 p-5">
       {posts.posts.map((post) => (
-        <Link href={`/posts/${post.slug}`} key={post.id}>
+        <Link className="max-h-96" href={`/posts/${post.slug}`} key={post.id}>
           <PostCard post={post} key={post.id} />
         </Link>
       ))}

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -3,18 +3,18 @@ import { PostCard } from "@/components/PostCard";
 import { PostsGetListDocument } from "@/gql/graphql";
 import { executeGraphql } from "@/lib/graphql";
 
-export default async function Page() {
+export const Posts = async () => {
   const posts = await executeGraphql(PostsGetListDocument);
 
   return (
-    <main className="flex min-h-96 flex-col items-center justify-between p-24">
-      <ul className="flex flex-wrap items-center justify-center gap-5">
-        {posts.posts.map((post) => (
-          <Link href={`/posts/${post.slug}`} key={post.id}>
-            <PostCard post={post} key={post.id} />
-          </Link>
-        ))}
-      </ul>
-    </main>
+    <ul className="p-5flex-wrap flex min-h-screen items-center justify-center gap-5">
+      {posts.posts.map((post) => (
+        <Link href={`/posts/${post.slug}`} key={post.id}>
+          <PostCard post={post} key={post.id} />
+        </Link>
+      ))}
+    </ul>
   );
-}
+};
+
+export default Posts;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -9,7 +9,7 @@ const footerLink = [
 
 export const Footer = () => {
   return (
-    <footer className="fixed inset-x-0 bottom-0 m-4 rounded-lg bg-white shadow dark:bg-gray-800">
+    <footer className="inset-x-0 bottom-0 rounded-lg bg-white py-1.5 shadow dark:bg-gray-800">
       <div className="mx-auto flex w-full max-w-screen-xl items-center justify-between p-2 md:p-4">
         <span className="text-center text-xs text-gray-500 dark:text-gray-400 md:text-sm">
           © 2024{" "}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -22,7 +22,7 @@ export type Item = {
 
 export const Header = ({ items }: { items: Item[] }) => {
   return (
-    <header className="sticky top-0 isolate z-10 py-4">
+    <header className="sticky inset-x-0 top-0 z-10 rounded-lg bg-white py-3 shadow dark:bg-gray-800">
       <div className="container">
         <div className="grid w-full grid-flow-col grid-cols-[repeat(3,1fr)] items-center justify-items-center gap-4">
           <Link href="/" legacyBehavior passHref>

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -1,0 +1,35 @@
+/* eslint-disable @next/next/no-img-element */
+import { type PostFragment } from "@/gql/graphql";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export const PostCard = ({ post }: { post: PostFragment }) => {
+  return (
+    <li className="transform list-none rounded-lg transition-transform duration-300 ease-in-out hover:scale-105">
+      <Card className="w-[350px] overflow-hidden rounded-xl">
+        <CardHeader className="pb-4 text-center">
+          <CardTitle className="line-clamp-3">{post.title}</CardTitle>
+        </CardHeader>
+        <CardDescription className="line-clamp-3 px-4 text-center">{post.excerpt}</CardDescription>
+        <CardContent className="group p-4">
+          <img className="rounded-lg" src={post.coverImage?.url} alt="Unable to load an image" />
+        </CardContent>
+        <CardFooter className="flex items-center justify-between px-3 py-2">
+          <p className="text-xs">{post?.date ? (post.date as string) : ""}</p>
+          <p className="text-xs italic">
+            {post.author?.name ? `${post.author?.name}` : "Author unknown"}
+          </p>
+        </CardFooter>
+      </Card>
+    </li>
+  );
+};
+
+PostCard.displayName = "PostCard";

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -13,7 +13,7 @@ import {
 export const PostCard = ({ post }: { post: PostFragment }) => {
   return (
     <li className="transform list-none rounded-lg transition-transform duration-300 ease-in-out hover:scale-105">
-      <Card className="w-[350px] overflow-hidden rounded-xl">
+      <Card className="w-[300px] overflow-hidden rounded-xl">
         <CardHeader className="pb-4 text-center">
           <CardTitle className="line-clamp-3">{post.title}</CardTitle>
         </CardHeader>

--- a/src/components/PostsList.tsx
+++ b/src/components/PostsList.tsx
@@ -1,0 +1,3 @@
+export const PostsList = () => {
+  return <div>PostsList</div>;
+};

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,79 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "rounded-lg border border-slate-200 bg-white text-slate-950 shadow-sm dark:border-slate-800 dark:bg-slate-950 dark:text-slate-50",
+      className
+    )}
+    {...props}
+  />
+))
+Card.displayName = "Card"
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+))
+CardHeader.displayName = "CardHeader"
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn(
+      "text-2xl font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+CardTitle.displayName = "CardTitle"
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-slate-500 dark:text-slate-400", className)}
+    {...props}
+  />
+))
+CardDescription.displayName = "CardDescription"
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+))
+CardContent.displayName = "CardContent"
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex items-center p-6 pt-0", className)}
+    {...props}
+  />
+))
+CardFooter.displayName = "CardFooter"
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-slate-200 bg-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg dark:border-slate-800 dark:bg-slate-950",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-white transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-slate-950 focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-slate-100 data-[state=open]:text-slate-500 dark:ring-offset-slate-950 dark:focus:ring-slate-300 dark:data-[state=open]:bg-slate-800 dark:data-[state=open]:text-slate-400">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-slate-500 dark:text-slate-400", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import * as React from "react"
+import * as ProgressPrimitive from "@radix-ui/react-progress"
+
+import { cn } from "@/lib/utils"
+
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+>(({ className, value, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative h-4 w-full overflow-hidden rounded-full bg-slate-100 dark:bg-slate-800",
+      className
+    )}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className="h-full w-full flex-1 bg-slate-900 transition-all dark:bg-slate-50"
+      style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+    />
+  </ProgressPrimitive.Root>
+))
+Progress.displayName = ProgressPrimitive.Root.displayName
+
+export { Progress }

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import { GripVertical } from "lucide-react"
+import * as ResizablePrimitive from "react-resizable-panels"
+
+import { cn } from "@/lib/utils"
+
+const ResizablePanelGroup = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof ResizablePrimitive.PanelGroup>) => (
+  <ResizablePrimitive.PanelGroup
+    className={cn(
+      "flex h-full w-full data-[panel-group-direction=vertical]:flex-col",
+      className
+    )}
+    {...props}
+  />
+)
+
+const ResizablePanel = ResizablePrimitive.Panel
+
+const ResizableHandle = ({
+  withHandle,
+  className,
+  ...props
+}: React.ComponentProps<typeof ResizablePrimitive.PanelResizeHandle> & {
+  withHandle?: boolean
+}) => (
+  <ResizablePrimitive.PanelResizeHandle
+    className={cn(
+      "relative flex w-px items-center justify-center bg-slate-200 after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-slate-950 focus-visible:ring-offset-1 data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90 dark:bg-slate-800 dark:focus-visible:ring-slate-300",
+      className
+    )}
+    {...props}
+  >
+    {withHandle && (
+      <div className="z-10 flex h-4 w-3 items-center justify-center rounded-sm border border-slate-200 bg-slate-200 dark:border-slate-800 dark:bg-slate-800">
+        <GripVertical className="h-2.5 w-2.5" />
+      </div>
+    )}
+  </ResizablePrimitive.PanelResizeHandle>
+)
+
+export { ResizablePanelGroup, ResizablePanel, ResizableHandle }

--- a/src/gql/gql.ts
+++ b/src/gql/gql.ts
@@ -15,6 +15,7 @@ import * as types from './graphql';
  */
 const documents = {
     "fragment Post on Post {\n  id\n  title\n  date\n  excerpt\n  slug\n  content {\n    text\n  }\n  coverImage {\n    url\n  }\n  author {\n    name\n  }\n}": types.PostFragmentDoc,
+    "query PostBySlug($slug: String!) {\n  post(where: {slug: $slug}) {\n    ...Post\n  }\n}": types.PostBySlugDocument,
     "query PostsGetList {\n  posts {\n    ...Post\n  }\n}": types.PostsGetListDocument,
 };
 
@@ -22,6 +23,10 @@ const documents = {
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
 export function graphql(source: "fragment Post on Post {\n  id\n  title\n  date\n  excerpt\n  slug\n  content {\n    text\n  }\n  coverImage {\n    url\n  }\n  author {\n    name\n  }\n}"): typeof import('./graphql').PostFragmentDoc;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "query PostBySlug($slug: String!) {\n  post(where: {slug: $slug}) {\n    ...Post\n  }\n}"): typeof import('./graphql').PostBySlugDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/src/gql/gql.ts
+++ b/src/gql/gql.ts
@@ -14,13 +14,18 @@ import * as types from './graphql';
  * Therefore it is highly recommended to use the babel or swc plugin for production.
  */
 const documents = {
-    "query PostsGetList {\n  posts {\n    id\n    title\n  }\n}": types.PostsGetListDocument,
+    "fragment Post on Post {\n  id\n  title\n  date\n  excerpt\n  slug\n  content {\n    text\n  }\n  coverImage {\n    url\n  }\n  author {\n    name\n  }\n}": types.PostFragmentDoc,
+    "query PostsGetList {\n  posts {\n    ...Post\n  }\n}": types.PostsGetListDocument,
 };
 
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
-export function graphql(source: "query PostsGetList {\n  posts {\n    id\n    title\n  }\n}"): typeof import('./graphql').PostsGetListDocument;
+export function graphql(source: "fragment Post on Post {\n  id\n  title\n  date\n  excerpt\n  slug\n  content {\n    text\n  }\n  coverImage {\n    url\n  }\n  author {\n    name\n  }\n}"): typeof import('./graphql').PostFragmentDoc;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "query PostsGetList {\n  posts {\n    ...Post\n  }\n}"): typeof import('./graphql').PostsGetListDocument;
 
 
 export function graphql(source: string) {

--- a/src/gql/graphql.ts
+++ b/src/gql/graphql.ts
@@ -6756,10 +6756,12 @@ export type _SystemDateTimeFieldVariation =
   | 'combined'
   | 'localization';
 
+export type PostFragment = { id: string, title: string, date: unknown, excerpt?: string | null, slug: string, content: { text: string }, coverImage?: { url: string } | null, author?: { name: string } | null };
+
 export type PostsGetListQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type PostsGetListQuery = { posts: Array<{ id: string, title: string }> };
+export type PostsGetListQuery = { posts: Array<{ id: string, title: string, date: unknown, excerpt?: string | null, slug: string, content: { text: string }, coverImage?: { url: string } | null, author?: { name: string } | null }> };
 
 export class TypedDocumentString<TResult, TVariables>
   extends String
@@ -6775,12 +6777,43 @@ export class TypedDocumentString<TResult, TVariables>
     return this.value;
   }
 }
-
+export const PostFragmentDoc = new TypedDocumentString(`
+    fragment Post on Post {
+  id
+  title
+  date
+  excerpt
+  slug
+  content {
+    text
+  }
+  coverImage {
+    url
+  }
+  author {
+    name
+  }
+}
+    `, {"fragmentName":"Post"}) as unknown as TypedDocumentString<PostFragment, unknown>;
 export const PostsGetListDocument = new TypedDocumentString(`
     query PostsGetList {
   posts {
-    id
-    title
+    ...Post
   }
 }
-    `) as unknown as TypedDocumentString<PostsGetListQuery, PostsGetListQueryVariables>;
+    fragment Post on Post {
+  id
+  title
+  date
+  excerpt
+  slug
+  content {
+    text
+  }
+  coverImage {
+    url
+  }
+  author {
+    name
+  }
+}`) as unknown as TypedDocumentString<PostsGetListQuery, PostsGetListQueryVariables>;

--- a/src/gql/graphql.ts
+++ b/src/gql/graphql.ts
@@ -6758,6 +6758,13 @@ export type _SystemDateTimeFieldVariation =
 
 export type PostFragment = { id: string, title: string, date: unknown, excerpt?: string | null, slug: string, content: { text: string }, coverImage?: { url: string } | null, author?: { name: string } | null };
 
+export type PostBySlugQueryVariables = Exact<{
+  slug: Scalars['String']['input'];
+}>;
+
+
+export type PostBySlugQuery = { post?: { id: string, title: string, date: unknown, excerpt?: string | null, slug: string, content: { text: string }, coverImage?: { url: string } | null, author?: { name: string } | null } | null };
+
 export type PostsGetListQueryVariables = Exact<{ [key: string]: never; }>;
 
 
@@ -6795,6 +6802,28 @@ export const PostFragmentDoc = new TypedDocumentString(`
   }
 }
     `, {"fragmentName":"Post"}) as unknown as TypedDocumentString<PostFragment, unknown>;
+export const PostBySlugDocument = new TypedDocumentString(`
+    query PostBySlug($slug: String!) {
+  post(where: {slug: $slug}) {
+    ...Post
+  }
+}
+    fragment Post on Post {
+  id
+  title
+  date
+  excerpt
+  slug
+  content {
+    text
+  }
+  coverImage {
+    url
+  }
+  author {
+    name
+  }
+}`) as unknown as TypedDocumentString<PostBySlugQuery, PostBySlugQueryVariables>;
 export const PostsGetListDocument = new TypedDocumentString(`
     query PostsGetList {
   posts {

--- a/src/graphql/Post.graphql
+++ b/src/graphql/Post.graphql
@@ -1,0 +1,16 @@
+fragment Post on Post {
+  id
+  title
+  date
+  excerpt
+  slug
+  content {
+    text
+  }
+  coverImage {
+    url
+  }
+  author {
+    name
+  }
+}

--- a/src/graphql/PostByID.graphql
+++ b/src/graphql/PostByID.graphql
@@ -1,0 +1,5 @@
+query PostBySlug($id: ID!) {
+  post(where: { id: $id }) {
+    ...Post
+  }
+}

--- a/src/graphql/PostByID.graphql
+++ b/src/graphql/PostByID.graphql
@@ -1,5 +1,0 @@
-query PostBySlug($id: ID!) {
-  post(where: { id: $id }) {
-    ...Post
-  }
-}

--- a/src/graphql/PostBySlug.graphql
+++ b/src/graphql/PostBySlug.graphql
@@ -1,0 +1,5 @@
+query PostBySlug($slug: String!) {
+  post(where: { slug: $slug }) {
+    ...Post
+  }
+}

--- a/src/graphql/PostsGetList.graphql
+++ b/src/graphql/PostsGetList.graphql
@@ -1,6 +1,5 @@
 query PostsGetList {
   posts {
-    id
-    title
+    ...Post
   }
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  overflow-y: scroll;
+}


### PR DESCRIPTION
What's new:
- create .graphql components needed to display data from the external library
- posts page - display list of posts
- post[slug] page - display a post based on a slug
- fixed styling for Header.tsx and Footer.tsx
- in globals.css set scrollbar visible to prevent moving content from side to side, if the page change vertical overflow